### PR TITLE
Distutils Removed for Python 3.12

### DIFF
--- a/NodeGraphQt/base/menu.py
+++ b/NodeGraphQt/base/menu.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 import re
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from qtpy import QtGui, QtCore
 
@@ -141,7 +141,7 @@ class NodeGraphMenu(object):
         """
         action = GraphAction(name, self._graph.viewer())
         action.graph = self._graph
-        if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
+        if Version(QtCore.qVersion()) >= Version('5.10'):
             action.setShortcutVisibleInContextMenu(True)
 
         if shortcut:
@@ -218,7 +218,7 @@ class NodesMenu(NodeGraphMenu):
 
         action = NodeAction(name, self._graph.viewer())
         action.graph = self._graph
-        if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
+        if Version(QtCore.qVersion()) >= Version('5.10'):
             action.setShortcutVisibleInContextMenu(True)
 
         if shortcut:

--- a/NodeGraphQt/widgets/viewer.py
+++ b/NodeGraphQt/widgets/viewer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import math
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from qtpy import QtGui, QtCore, QtWidgets
 
@@ -201,7 +201,7 @@ class NodeViewer(QtWidgets.QGraphicsView):
         if self._undo_action and self._redo_action:
             self._undo_action.setShortcuts(QtGui.QKeySequence.StandardKey.Undo)
             self._redo_action.setShortcuts(QtGui.QKeySequence.StandardKey.Redo)
-            if LooseVersion(QtCore.qVersion()) >= LooseVersion('5.10'):
+            if Version(QtCore.qVersion()) >= Version('5.10'):
                 self._undo_action.setShortcutVisibleInContextMenu(True)
                 self._redo_action.setShortcutVisibleInContextMenu(True)
 


### PR DESCRIPTION
As pointed out by https://docs.python.org/3.10/library/distutils.html, distutils.version.LooseVersion is no longer supported in Python >= 3.12.

**Possible Solution:**

We should migrate to [packaging.version.Version](https://packaging.pypa.io/en/latest/version.html#packaging.version.Version).